### PR TITLE
iOS viewport safe areas

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -66,7 +66,7 @@ function SheetContent({
           side === 'top' &&
             'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
           side === 'bottom' &&
-            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
+            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t pb-safe-bottom',
           className
         )}
         {...props}

--- a/src/routes/Map.tsx
+++ b/src/routes/Map.tsx
@@ -172,7 +172,7 @@ const Map: React.FunctionComponent = () => {
         ]}
         style={{
           width: '100vw',
-          height: '100vh',
+          height: '100dvh',
         }}
         minZoom={9}
         //disables zooming while an incident is selected
@@ -194,7 +194,7 @@ const Map: React.FunctionComponent = () => {
       >
         <AttributionControl compact={true} position="bottom-left" />
 
-        <SafeArea className="h-dvh pb-safe-bottom">
+        <SafeArea top className="h-dvh">
           {/* Overlay button for opening the drawer */}
           {!drawerOpen && (
             <Button
@@ -225,7 +225,8 @@ const Map: React.FunctionComponent = () => {
           />
 
           <ButtonGroup
-            className="absolute bottom-[25px] right-[25px]"
+            className="absolute right-[25px]"
+            style={{ bottom: 'calc(25px + var(--safe-bottom))' }}
             hidden={Boolean(drawerOpen || selectedIncident)}
           >
             <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix iOS viewport safe areas to allow background content to extend fully while keeping interactive elements properly spaced.

---
Linear Issue: [TPSCALL-1](https://linear.app/drnt/issue/TPSCALL-1/fix-viewport-not-being-optimized-for-ios-26-full-screen)

<p><a href="https://cursor.com/agents/bc-4335fe5b-9960-4fba-b328-7d57dcf29ea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4335fe5b-9960-4fba-b328-7d57dcf29ea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->