### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-//npm.pkg.github.com/:_authToken=$PERSONAL_GITHUB_TOKEN
+//npm.pkg.github.com/:_authToken=${PERSONAL_GITHUB_TOKEN}
 @rdrnt:registry=https://npm.pkg.github.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,21 +11,48 @@ Firebase Firestore project, and tiles come from Mapbox.
 
 The dev environment cannot fully run without owner-controlled credentials:
 
-- `PERSONAL_GITHUB_TOKEN` — **hard blocker for `yarn install`**. `.npmrc` routes
-  the `@rdrnt` scope (the private `@rdrnt/tps-calls-shared` types package) to
-  GitHub Packages (`https://npm.pkg.github.com`). Without a token that has
-  `read:packages` access to the `rdrnt` account's packages, install fails with
-  `401/403`. The default Cursor `gh` token does **not** have access (403).
+- `PERSONAL_GITHUB_TOKEN` — **required for every `yarn` command**. `.npmrc`
+  routes the `@rdrnt` scope (the private `@rdrnt/tps-calls-shared` types package)
+  to GitHub Packages (`https://npm.pkg.github.com`) and authenticates with this
+  token. It needs `read:packages` for the `rdrnt` account (the repo owner's own
+  PAT works; the default Cursor `gh` token does NOT — it returns 403).
+  - The token is injected as an env var in cloud sessions, so the update script
+    and the agent's shells have it automatically. **Caveat:** because `.npmrc`
+    uses `${PERSONAL_GITHUB_TOKEN}`, yarn (classic v1) hard-errors with
+    "Failed to replace env in config" on ANY command (even `yarn start`) if the
+    variable is unset in that shell. If you start a long-running process in a
+    fresh `tmux` server that predates the secret, pass the var through
+    (`tmux new-session ... -e "PERSONAL_GITHUB_TOKEN=$PERSONAL_GITHUB_TOKEN"`) or
+    start tmux from a shell that already has it.
+  - Note: the committed `.npmrc` previously used `$PERSONAL_GITHUB_TOKEN` (no
+    braces), which npm/yarn never expand → install failed with 401. It is now
+    `${PERSONAL_GITHUB_TOKEN}`.
 - Firebase config files: `src/config/firebase/development.json` and
   `src/config/firebase/production.json` are gitignored and imported directly by
   `src/helpers/firebase/index.ts`. The app fails to build/run if they are absent.
   In dev (`yarn start`), `import.meta.env.DEV === true` so `development.json` is
   used. Each file is the standard Firebase web config object
   (`apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, `appId`).
+  Provide them via the `FIREBASE_DEVELOPMENT_CONFIG` / `FIREBASE_PRODUCTION_CONFIG`
+  secrets (write the JSON to those files during setup) or place the files
+  directly. The Firestore project is `toronto-emergency-calls`; its web config
+  is public (served in the live `tpscalls.live` JS bundle) and the `incidents`
+  collection is public-read, so it can be recovered from the live site if needed.
 - `VITE_MAPBOX_API_KEY` (in `.env`) — without a valid Mapbox token the home
   page (`/` and `/:id`, the map) stays on "Loading map…" and never finishes.
   Other env vars read in `src/helpers/environment.ts`: `VITE_SENTRY_DSN`,
   `VITE_GANALYTICS_KEY` (both optional for local dev).
+
+### Map rendering requires WebGL (GUI test caveat)
+
+The map uses `mapbox-gl`, which needs WebGL. The in-VM Chrome used by the
+computer-use tool has no WebGL, so the map throws
+`Error: Map is not supported by this browser` and stays on the loader there
+(non-map routes like `/download` and `/contact` render fine). To screenshot the
+working map, use headless Chrome with software WebGL, e.g.
+`google-chrome --headless=new --no-sandbox --user-data-dir=/tmp/p --use-gl=angle --use-angle=swiftshader-webgl --enable-unsafe-swiftshader --virtual-time-budget=20000 --screenshot=out.png http://localhost:3000/`.
+The loader only clears once BOTH the Mapbox `onLoad` fires AND at least one
+incident has been fetched from Firestore (see `src/routes/Map.tsx`).
 
 ### Node / package manager
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is `tpscalls-frontend`: a Vite + React 19 + TypeScript single-page app
+(Redux Toolkit, react-map-gl/Mapbox, Firebase Firestore). There is one product
+(the web frontend) and no backend in this repo — data is read from a remote
+Firebase Firestore project, and tiles come from Mapbox.
+
+### Required external credentials (must be provided as secrets)
+
+The dev environment cannot fully run without owner-controlled credentials:
+
+- `PERSONAL_GITHUB_TOKEN` — **hard blocker for `yarn install`**. `.npmrc` routes
+  the `@rdrnt` scope (the private `@rdrnt/tps-calls-shared` types package) to
+  GitHub Packages (`https://npm.pkg.github.com`). Without a token that has
+  `read:packages` access to the `rdrnt` account's packages, install fails with
+  `401/403`. The default Cursor `gh` token does **not** have access (403).
+- Firebase config files: `src/config/firebase/development.json` and
+  `src/config/firebase/production.json` are gitignored and imported directly by
+  `src/helpers/firebase/index.ts`. The app fails to build/run if they are absent.
+  In dev (`yarn start`), `import.meta.env.DEV === true` so `development.json` is
+  used. Each file is the standard Firebase web config object
+  (`apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, `appId`).
+- `VITE_MAPBOX_API_KEY` (in `.env`) — without a valid Mapbox token the home
+  page (`/` and `/:id`, the map) stays on "Loading map…" and never finishes.
+  Other env vars read in `src/helpers/environment.ts`: `VITE_SENTRY_DSN`,
+  `VITE_GANALYTICS_KEY` (both optional for local dev).
+
+### Node / package manager
+
+- Use the default Node 22 toolchain (`/exec-daemon/node`) with `yarn` 1.x. The
+  committed `.nvmrc` pins `20.19.4`, but Node 22 is the environment default and
+  builds/serves the app fine; do not fight the PATH to force Node 20.
+- `node_modules` hot-reload caveat: after changing dependencies, restart
+  `yarn start` (Vite dev server) — newly installed packages are not always picked
+  up by an already-running dev server.
+
+### Commands (defined in `package.json`)
+
+- Run (dev): `yarn start` → Vite dev server on `http://localhost:3000`.
+- Build: `yarn build` (prod) or `yarn build:dev` (dev mode, no Sentry upload).
+- Lint: `yarn lint` (ESLint is **not** type-aware here — no `project` set).
+  Note: the repo is **not** currently lint/format clean (`yarn lint` and
+  `yarn format:check` report many pre-existing `prettier/prettier` issues);
+  this is a repo state issue, not an environment problem.
+- Type-check: `yarn type-check` (`tsc --noEmit`).
+- Test: `yarn test` (Vitest + jsdom). There are currently **no** test files in
+  the repo, so this is effectively a no-op until tests are added.
+
+### Useful routes for smoke-testing without Mapbox/Firebase data
+
+`/download` and `/contact` render full content with no map/data dependency and
+are the easiest pages to confirm the app shell + routing work. `/` and `/:id`
+require a working Mapbox token (and Firestore data) to fully render.
+
+### Known dev-server quirk
+
+Vite dev serves many unbundled ES modules; in a resource-constrained browser
+this can intermittently produce `net::ERR_INSUFFICIENT_RESOURCES` and a blank
+page that resolves on refresh. The production build (`yarn build`) bundles
+everything and is not affected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,37 +7,38 @@ This repo is `tpscalls-frontend`: a Vite + React 19 + TypeScript single-page app
 (the web frontend) and no backend in this repo — data is read from a remote
 Firebase Firestore project, and tiles come from Mapbox.
 
-### Required external credentials (must be provided as secrets)
+### Required credentials
 
-The dev environment cannot fully run without owner-controlled credentials:
+> This is a public repo. Never commit secret values (tokens, API keys, Firebase
+> config) or paste them into this file. Supply them only via Cursor Secrets;
+> they are injected as env vars at runtime and the gitignored files below are
+> generated from them.
 
-- `PERSONAL_GITHUB_TOKEN` — **required for every `yarn` command**. `.npmrc`
-  routes the `@rdrnt` scope (the private `@rdrnt/tps-calls-shared` types package)
-  to GitHub Packages (`https://npm.pkg.github.com`) and authenticates with this
-  token. It needs `read:packages` for the `rdrnt` account (the repo owner's own
-  PAT works; the default Cursor `gh` token does NOT — it returns 403).
-  - The token is injected as an env var in cloud sessions, so the update script
-    and the agent's shells have it automatically. **Caveat:** because `.npmrc`
-    uses `${PERSONAL_GITHUB_TOKEN}`, yarn (classic v1) hard-errors with
+The dev environment needs these secrets (names only — values live in Cursor Secrets):
+
+- `PERSONAL_GITHUB_TOKEN` — **required for every `yarn` command**. `.npmrc` points
+  the private npm scope at GitHub Packages and authenticates with this token
+  (needs `read:packages` for that scope's owner). The default Cursor `gh` token
+  does NOT have access.
+  - Injected as an env var in cloud sessions, so the update script and the
+    agent's shells have it automatically. **Caveat:** because `.npmrc` uses
+    `${PERSONAL_GITHUB_TOKEN}`, yarn (classic v1) hard-errors with
     "Failed to replace env in config" on ANY command (even `yarn start`) if the
     variable is unset in that shell. If you start a long-running process in a
     fresh `tmux` server that predates the secret, pass the var through
     (`tmux new-session ... -e "PERSONAL_GITHUB_TOKEN=$PERSONAL_GITHUB_TOKEN"`) or
     start tmux from a shell that already has it.
-  - Note: the committed `.npmrc` previously used `$PERSONAL_GITHUB_TOKEN` (no
-    braces), which npm/yarn never expand → install failed with 401. It is now
-    `${PERSONAL_GITHUB_TOKEN}`.
-- Firebase config files: `src/config/firebase/development.json` and
-  `src/config/firebase/production.json` are gitignored and imported directly by
-  `src/helpers/firebase/index.ts`. The app fails to build/run if they are absent.
-  In dev (`yarn start`), `import.meta.env.DEV === true` so `development.json` is
-  used. Each file is the standard Firebase web config object
-  (`apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, `appId`).
-  These are provided via the `FIREBASE_DEVELOPMENT_CONFIG` /
-  `FIREBASE_PRODUCTION_CONFIG` secrets, and the **update script materializes them
-  into the two files** on startup. If only `FIREBASE_DEVELOPMENT_CONFIG` is set,
-  the update script also uses it for `production.json`. If you need to recreate
-  them by hand:
+  - Note: `.npmrc` must use `${PERSONAL_GITHUB_TOKEN}` (with braces); npm/yarn
+    never expand the unbraced `$PERSONAL_GITHUB_TOKEN`, so that form fails with 401.
+- Firebase config: `src/config/firebase/development.json` and `production.json`
+  are gitignored and imported directly by `src/helpers/firebase/index.ts`, so the
+  app fails to build/run if absent. In dev (`yarn start`) `import.meta.env.DEV`
+  is true, so `development.json` is used. Each is a standard Firebase web config
+  object (`apiKey`, `authDomain`, `projectId`, `storageBucket`,
+  `messagingSenderId`, `appId`). They are generated from the
+  `FIREBASE_DEVELOPMENT_CONFIG` / `FIREBASE_PRODUCTION_CONFIG` secrets by the
+  update script (if only the development one is set, it is used for both). To
+  recreate by hand:
   `mkdir -p src/config/firebase && printf '%s' "$FIREBASE_DEVELOPMENT_CONFIG" > src/config/firebase/development.json`.
 - `VITE_MAPBOX_API_KEY` — required for the map (`/` and `/:id`); without it the
   home page stays on "Loading map…". Vite reads `VITE_`-prefixed vars straight

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,15 +33,17 @@ The dev environment cannot fully run without owner-controlled credentials:
   In dev (`yarn start`), `import.meta.env.DEV === true` so `development.json` is
   used. Each file is the standard Firebase web config object
   (`apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, `appId`).
-  Provide them via the `FIREBASE_DEVELOPMENT_CONFIG` / `FIREBASE_PRODUCTION_CONFIG`
-  secrets (write the JSON to those files during setup) or place the files
-  directly. The Firestore project is `toronto-emergency-calls`; its web config
-  is public (served in the live `tpscalls.live` JS bundle) and the `incidents`
-  collection is public-read, so it can be recovered from the live site if needed.
-- `VITE_MAPBOX_API_KEY` (in `.env`) — without a valid Mapbox token the home
-  page (`/` and `/:id`, the map) stays on "Loading map…" and never finishes.
-  Other env vars read in `src/helpers/environment.ts`: `VITE_SENTRY_DSN`,
-  `VITE_GANALYTICS_KEY` (both optional for local dev).
+  These are provided via the `FIREBASE_DEVELOPMENT_CONFIG` /
+  `FIREBASE_PRODUCTION_CONFIG` secrets, and the **update script materializes them
+  into the two files** on startup. If only `FIREBASE_DEVELOPMENT_CONFIG` is set,
+  the update script also uses it for `production.json`. If you need to recreate
+  them by hand:
+  `mkdir -p src/config/firebase && printf '%s' "$FIREBASE_DEVELOPMENT_CONFIG" > src/config/firebase/development.json`.
+- `VITE_MAPBOX_API_KEY` — required for the map (`/` and `/:id`); without it the
+  home page stays on "Loading map…". Vite reads `VITE_`-prefixed vars straight
+  from `process.env`, so the injected secret is picked up automatically — no
+  `.env` file is needed in cloud sessions. Other optional vars in
+  `src/helpers/environment.ts`: `VITE_SENTRY_DSN`, `VITE_GANALYTICS_KEY`.
 
 ### Map rendering requires WebGL (GUI test caveat)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the Cloud Agent development environment for `tpscalls-frontend` (Vite + React 19 + TypeScript), end-to-end with real credentials.

- Fixes `.npmrc` to use `${PERSONAL_GITHUB_TOKEN}` (braces) so yarn expands the token and can install the private scoped package. The previous unbraced form is never expanded by npm/yarn, so install failed with `401`.
- Adds `AGENTS.md` with durable cloud setup notes (token requirement for all yarn commands, Firebase config materialization from secrets, Mapbox-from-env, and the WebGL/map GUI caveat). Written to avoid leaking any secret values or identifying specifics.

## Update script

```
yarn install --frozen-lockfile
mkdir -p src/config/firebase
if [ -n "$FIREBASE_DEVELOPMENT_CONFIG" ]; then printf '%s' "$FIREBASE_DEVELOPMENT_CONFIG" > src/config/firebase/development.json; fi
if [ -n "$FIREBASE_PRODUCTION_CONFIG" ]; then printf '%s' "$FIREBASE_PRODUCTION_CONFIG" > src/config/firebase/production.json; elif [ -n "$FIREBASE_DEVELOPMENT_CONFIG" ]; then printf '%s' "$FIREBASE_DEVELOPMENT_CONFIG" > src/config/firebase/production.json; fi
```

Installs deps and materializes the gitignored Firebase config files from the `FIREBASE_DEVELOPMENT_CONFIG` / `FIREBASE_PRODUCTION_CONFIG` secrets. `VITE_MAPBOX_API_KEY` is read directly from `process.env` by Vite, so no `.env` file is needed.

## End-to-end validation

- `yarn install --frozen-lockfile` — resolves the private scoped package via GitHub Packages.
- `yarn build:dev` — successful Vite production bundle.
- `yarn lint` / `yarn type-check` — run successfully; both report pre-existing repo issues (unrelated to the environment).
- `yarn start` — dev server on `http://localhost:3000`; the real interactive Mapbox map renders with live incident pins from the development Firestore project.

The Toronto map with live police-call markers, running on the provided dev Firebase config + Mapbox token:

[tpscalls map with live incident pins (real config)](https://cursor.com/agents/bc-20d2822a-1da9-451b-aecf-3784e6670a96/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftpscalls_map_real_config.png)

## Notes

- The Mapbox map requires WebGL. The in-VM computer-use Chrome lacks WebGL (`Map is not supported by this browser`), so the map was captured via headless Chrome with software WebGL (`--use-angle=swiftshader-webgl --enable-unsafe-swiftshader`). Non-map routes (`/download`, `/contact`) render normally.
- Firebase config files are gitignored (not committed); they are supplied via secrets and written by the update script.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20d2822a-1da9-451b-aecf-3784e6670a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20d2822a-1da9-451b-aecf-3784e6670a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

