### PR TITLE
v3.3.0 - SEO Upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,15 +8,21 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
 
-    <title>tpscalls.live</title>
-    <meta name="keywords" content="Toronto Police, Calls, Map, Service Calls, GTA, Toronto, Police, Police calls">
+    <title>Live Toronto Police Calls Map | tpscalls</title>
     <meta name="author" content="Riley Durant">
-    <meta name="description" content="Real-time mapping of locations where police have responded to a call for service. These calls include incidents such as arrests, gun calls, collisions involving people or property, assaults, industrial accidents or disputes. Some calls for service will be, or are being, excluded for privacy reasons, including calls respecting domestic violence, sexual assault, or medical distress. Others calls may be excluded because they are part of an ongoing police operation.">
+    <meta name="description" content="Live map of Toronto Police calls for service across the city, updated in real time.">
 
-    <meta property="og:title" content="tpscalls.live" />
+    <meta property="og:title" content="Live Toronto Police Calls Map | tpscalls" />
     <meta property="og:url" content="https://www.tpscalls.live" />
-    <meta property="og:image" content="/images/map.jpg" />
-    <meta property="og:description" content="Real-time mapping of locations where the Toronto Police have responded to a call for service.">
+    <meta property="og:image" content="https://www.tpscalls.live/images/map.jpg" />
+    <meta property="og:description" content="Live map of Toronto Police calls for service across the city, updated in real time.">
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="tpscalls" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Live Toronto Police Calls Map | tpscalls" />
+    <meta name="twitter:description" content="Live map of Toronto Police calls for service across the city, updated in real time." />
+    <meta name="twitter:image" content="https://www.tpscalls.live/images/map.jpg" />
 
     <link rel="apple-touch-icon" href="/images/logo192.png" />
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpscalls-frontend",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -67,3 +67,5 @@ Disallow: /*?*_format=json
 Allow: /
 Allow: /contact
 Allow: /download
+
+Sitemap: https://www.tpscalls.live/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.tpscalls.live/</loc>
+  </url>
+  <url>
+    <loc>https://www.tpscalls.live/contact</loc>
+  </url>
+  <url>
+    <loc>https://www.tpscalls.live/download</loc>
+  </url>
+</urlset>

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -1,0 +1,37 @@
+export const SITE_NAME = 'tpscalls';
+export const SITE_URL = 'https://www.tpscalls.live';
+export const DEFAULT_TITLE = 'Live Toronto Police Calls Map | tpscalls';
+
+export type RouteMetadata = {
+  title: string;
+  description: string;
+  canonicalPath: string;
+};
+
+export const MAP_METADATA: RouteMetadata = {
+  title: DEFAULT_TITLE,
+  description:
+    'Live map of Toronto Police calls for service across the city, updated in real time.',
+  canonicalPath: '/',
+};
+
+export const CONTACT_METADATA: RouteMetadata = {
+  title: 'Contact | tpscalls',
+  description:
+    'Get in touch about tpscalls — report bugs, share ideas, or ask questions about the data.',
+  canonicalPath: '/contact',
+};
+
+export const DOWNLOAD_METADATA: RouteMetadata = {
+  title: 'Download the tpscalls App | tpscalls',
+  description:
+    'Download the tpscalls app for iOS and Android. Every Toronto Police call on the map the moment it is dispatched.',
+  canonicalPath: '/download',
+};
+
+export const TRAFFIC_CAMS_METADATA: RouteMetadata = {
+  title: 'Toronto Traffic Cameras | tpscalls',
+  description:
+    'Real-time traffic camera feeds from intersections across Toronto.',
+  canonicalPath: '/traffic-cams',
+};

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -35,3 +35,12 @@ export const TRAFFIC_CAMS_METADATA: RouteMetadata = {
     'Real-time traffic camera feeds from intersections across Toronto.',
   canonicalPath: '/traffic-cams',
 };
+
+export const buildIncidentTitle = (name: string, location: string): string => {
+  // Historical incidents can omit cross streets, so the title must not expose an empty `at` fragment.
+  if (location.trim()) {
+    return `${name} at ${location} | ${SITE_NAME}`;
+  }
+
+  return `${name} | ${SITE_NAME}`;
+};

--- a/src/hooks/usePageMetadata.test.tsx
+++ b/src/hooks/usePageMetadata.test.tsx
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SITE_URL } from '@/config/seo';
+
+import usePageMetadata from './usePageMetadata';
+
+const setupDocumentHead = (): void => {
+  document.head.innerHTML = `
+    <title>Initial Title</title>
+    <meta name="description" content="Initial description" />
+    <meta property="og:title" content="Initial OG title" />
+    <meta property="og:description" content="Initial OG description" />
+    <meta property="og:url" content="${SITE_URL}" />
+    <meta name="twitter:title" content="Initial Twitter title" />
+    <meta name="twitter:description" content="Initial Twitter description" />
+  `;
+  document.title = 'Initial Title';
+};
+
+describe('usePageMetadata', () => {
+  beforeEach(() => {
+    setupDocumentHead();
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('updates title, description, Open Graph, Twitter, and canonical tags', () => {
+    const { unmount } = renderHook(() =>
+      usePageMetadata({
+        title: 'Contact | tpscalls',
+        description: 'Contact us about tpscalls.',
+        canonicalPath: '/contact',
+      })
+    );
+
+    expect(document.title).toBe('Contact | tpscalls');
+    expect(
+      document.querySelector('meta[name="description"]')?.getAttribute('content')
+    ).toBe('Contact us about tpscalls.');
+    expect(
+      document.querySelector('meta[property="og:title"]')?.getAttribute('content')
+    ).toBe('Contact | tpscalls');
+    expect(
+      document
+        .querySelector('meta[property="og:description"]')
+        ?.getAttribute('content')
+    ).toBe('Contact us about tpscalls.');
+    expect(
+      document.querySelector('meta[property="og:url"]')?.getAttribute('content')
+    ).toBe(`${SITE_URL}/contact`);
+    expect(
+      document
+        .querySelector('meta[name="twitter:title"]')
+        ?.getAttribute('content')
+    ).toBe('Contact | tpscalls');
+    expect(
+      document
+        .querySelector('meta[name="twitter:description"]')
+        ?.getAttribute('content')
+    ).toBe('Contact us about tpscalls.');
+    expect(
+      document.querySelector('link[rel="canonical"]')?.getAttribute('href')
+    ).toBe(`${SITE_URL}/contact`);
+
+    unmount();
+
+    expect(document.title).toBe('Initial Title');
+    expect(
+      document.querySelector('meta[name="description"]')?.getAttribute('content')
+    ).toBe('Initial description');
+    expect(document.querySelector('link[rel="canonical"]')).toBeNull();
+  });
+
+  it('restores an existing canonical link instead of removing it', () => {
+    const existingCanonical = document.createElement('link');
+    existingCanonical.rel = 'canonical';
+    existingCanonical.href = `${SITE_URL}/existing`;
+    document.head.appendChild(existingCanonical);
+
+    const { unmount } = renderHook(() =>
+      usePageMetadata({
+        title: 'Download the tpscalls App | tpscalls',
+        description: 'Download page description.',
+        canonicalPath: '/download',
+      })
+    );
+
+    expect(
+      document.querySelector('link[rel="canonical"]')?.getAttribute('href')
+    ).toBe(`${SITE_URL}/download`);
+
+    unmount();
+
+    expect(
+      document.querySelector('link[rel="canonical"]')?.getAttribute('href')
+    ).toBe(`${SITE_URL}/existing`);
+  });
+});

--- a/src/hooks/usePageMetadata.ts
+++ b/src/hooks/usePageMetadata.ts
@@ -1,0 +1,120 @@
+import { useEffect } from 'react';
+
+import { SITE_URL } from '@/config/seo';
+
+type PageMetadataOptions = {
+  title: string;
+  description: string;
+  canonicalPath: string;
+};
+
+type MetaTagSpec = {
+  attr: 'name' | 'property';
+  key: string;
+  value: string;
+};
+
+const getMetaElement = (
+  key: string,
+  attr: 'name' | 'property'
+): HTMLMetaElement => {
+  const selector =
+    attr === 'name' ? `meta[name="${key}"]` : `meta[property="${key}"]`;
+  const existing = document.querySelector(selector);
+
+  if (existing instanceof HTMLMetaElement) {
+    return existing;
+  }
+
+  const element = document.createElement('meta');
+  element.setAttribute(attr, key);
+  document.head.appendChild(element);
+  return element;
+};
+
+const usePageMetadata = ({
+  title,
+  description,
+  canonicalPath,
+}: PageMetadataOptions): void => {
+  useEffect(() => {
+    const priorTitle = document.title;
+    const canonicalUrl = `${SITE_URL}${canonicalPath}`;
+
+    const metaTags: MetaTagSpec[] = [
+      { attr: 'name', key: 'description', value: description },
+      { attr: 'property', key: 'og:title', value: title },
+      { attr: 'property', key: 'og:description', value: description },
+      { attr: 'property', key: 'og:url', value: canonicalUrl },
+      { attr: 'name', key: 'twitter:title', value: title },
+      { attr: 'name', key: 'twitter:description', value: description },
+    ];
+
+    const priorMetaValues = metaTags.map(({ attr, key }) => {
+      const selector =
+        attr === 'name' ? `meta[name="${key}"]` : `meta[property="${key}"]`;
+      const element = document.querySelector(selector);
+
+      return {
+        element,
+        priorContent:
+          element instanceof HTMLMetaElement
+            ? element.getAttribute('content')
+            : null,
+        created: !(element instanceof HTMLMetaElement),
+        attr,
+        key,
+      };
+    });
+
+    document.title = title;
+
+    for (const { attr, key, value } of metaTags) {
+      getMetaElement(key, attr).setAttribute('content', value);
+    }
+
+    const existingCanonical = document.querySelector('link[rel="canonical"]');
+    const createdCanonical = !(existingCanonical instanceof HTMLLinkElement);
+    const canonicalElement = createdCanonical
+      ? document.createElement('link')
+      : existingCanonical;
+    const priorCanonicalHref = createdCanonical
+      ? null
+      : canonicalElement.getAttribute('href');
+
+    if (createdCanonical) {
+      canonicalElement.rel = 'canonical';
+      document.head.appendChild(canonicalElement);
+    }
+
+    canonicalElement.href = canonicalUrl;
+
+    return () => {
+      // Restoration prevents metadata from a lazy route leaking into the next route during client-side navigation.
+      document.title = priorTitle;
+
+      for (const { element, priorContent, created } of priorMetaValues) {
+        if (created) {
+          element?.remove();
+          continue;
+        }
+
+        if (element instanceof HTMLMetaElement) {
+          if (priorContent === null) {
+            element.removeAttribute('content');
+          } else {
+            element.setAttribute('content', priorContent);
+          }
+        }
+      }
+
+      if (createdCanonical) {
+        canonicalElement.remove();
+      } else if (priorCanonicalHref !== null) {
+        canonicalElement.setAttribute('href', priorCanonicalHref);
+      }
+    };
+  }, [title, description, canonicalPath]);
+};
+
+export default usePageMetadata;

--- a/src/routes/Contact.tsx
+++ b/src/routes/Contact.tsx
@@ -4,7 +4,9 @@ import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import SiteHeader from '@/components/SiteHeader';
 import SiteFooter from '@/components/SiteFooter';
+import { CONTACT_METADATA } from '@/config/seo';
 import useAnalyticsPageView from '@/hooks/useAnalyticsPageView';
+import usePageMetadata from '@/hooks/usePageMetadata';
 
 // Kept as separate parts (never a contiguous `user@domain` literal) so the
 // address doesn't appear in the served HTML/JS bundle for regex-based email
@@ -14,6 +16,7 @@ const EMAIL_USER = 'riley';
 const EMAIL_DOMAIN = 'drnt.ca';
 
 const ContactPage: FunctionComponent = () => {
+  usePageMetadata(CONTACT_METADATA);
   useAnalyticsPageView({ path: '/contact' });
 
   const email = `${EMAIL_USER}@${EMAIL_DOMAIN}`;

--- a/src/routes/Download/index.tsx
+++ b/src/routes/Download/index.tsx
@@ -6,7 +6,9 @@ import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import SiteHeader from '@/components/SiteHeader';
 import SiteFooter from '@/components/SiteFooter';
+import { DOWNLOAD_METADATA } from '@/config/seo';
 import useAnalyticsPageView from '@/hooks/useAnalyticsPageView';
+import usePageMetadata from '@/hooks/usePageMetadata';
 import { useAppSelector } from '@/store';
 
 import { RECENT_WINDOW_MINUTES } from './lib';
@@ -60,6 +62,7 @@ const FEATURES = [
 ];
 
 const DownloadPage: FunctionComponent = () => {
+  usePageMetadata(DOWNLOAD_METADATA);
   useAnalyticsPageView({ path: '/download' });
 
   const recentCalls = useRecentCallCount();

--- a/src/routes/Map.tsx
+++ b/src/routes/Map.tsx
@@ -13,6 +13,8 @@ import {
 import { toast, Toaster } from 'sonner';
 
 import { MAPBOX_THEME_URL, Colors } from '../config';
+import { buildIncidentTitle, MAP_METADATA } from '@/config/seo';
+import usePageMetadata from '@/hooks/usePageMetadata';
 import { Environment, Analytics } from '../helpers';
 import * as FirebaseIncidents from '../helpers/firebase/incident';
 
@@ -57,6 +59,22 @@ const Map: React.FunctionComponent = () => {
   const [isMapLoaded, setIsMapLoaded] = React.useState<boolean>(false);
   const [interactingWithMap, setInteractingWithMap] =
     React.useState<boolean>(false);
+
+  const pageTitle = selectedIncident
+    ? buildIncidentTitle(selectedIncident.name, selectedIncident.location)
+    : MAP_METADATA.title;
+  const pageDescription = selectedIncident
+    ? selectedIncident.location.trim()
+      ? `${selectedIncident.name} at ${selectedIncident.location}. Live Toronto Police call on tpscalls.`
+      : `${selectedIncident.name}. Live Toronto Police call on tpscalls.`
+    : MAP_METADATA.description;
+  const canonicalPath = id ? `/${id}` : MAP_METADATA.canonicalPath;
+
+  usePageMetadata({
+    title: pageTitle,
+    description: pageDescription,
+    canonicalPath,
+  });
 
   // Finds and returns an incident from the store or database
   const getIncidentWithId = async (
@@ -150,6 +168,7 @@ const Map: React.FunctionComponent = () => {
 
   return (
     <>
+      <h1 className="sr-only">Live Toronto Police Calls Map</h1>
       <ReactMapGl
         ref={refForMap}
         mapboxAccessToken={Environment.config.MAPBOX_API_KEY}

--- a/src/routes/TrafficCams.tsx
+++ b/src/routes/TrafficCams.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { collection, getDocs, orderBy, query } from 'firebase/firestore';
 import Fuse from 'fuse.js';
 
+import { TRAFFIC_CAMS_METADATA } from '@/config/seo';
+import usePageMetadata from '@/hooks/usePageMetadata';
+
 import { Analytics } from '../helpers';
 import {
   Card,
@@ -20,6 +23,8 @@ import {
 } from '../types';
 
 const TrafficCams = () => {
+  usePageMetadata(TRAFFIC_CAMS_METADATA);
+
   const [search, setSearch] = useState('');
   const [torontoTrafficCameras, setTorontoTrafficCameras] = useState<
     LocalTorontoTrafficCamera[]


### PR DESCRIPTION
**What**
Adds descriptive static and per-route metadata, sitemap discovery, and incident-aware browser titles to the frontend.

**Why**
Current search results show every route as `tpscalls.live`, and selecting an incident leaves the tab title without the call name or intersection.